### PR TITLE
Indicate free-threaded support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,19 @@ class lazy_cythonize(list):
 
 def extensions():
     from Cython.Build import cythonize
+    from Cython.Compiler.Version import version as cython_version
+    from packaging.version import Version
     ext = Extension("pyrevolve.crevolve", sources=["pyrevolve/schedulers/crevolve.pyx",
                                                    "src/revolve_c.cpp",
                                                    "src/revolve.cpp"],
                     include_dirs=[".", "pyrevolve"],
                     language="c++")
-    return cythonize([ext])
+
+    compiler_directives = {}
+    if Version(cython_version) >= Version("3.1.0"):
+        compiler_directives["freethreading_compatible"] = True
+
+    return cythonize([ext], compiler_directives=compiler_directives)
 
 
 with open("README.md", "r") as fh:


### PR DESCRIPTION
Updates the setup script to pass a compiler directive to `cythonize` indicating that pyrevolve is safe to run without the GIL. Without this change, the GIL is reenabled whenever a free-threaded build imports the module.